### PR TITLE
Allow to read kdeglobals configuration

### DIFF
--- a/org.kde.krita.yaml
+++ b/org.kde.krita.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --filesystem=host
+  - --filesystem=xdg-config/kdeglobals:ro
   - --env=PYTHONPATH=/app/lib/python3/dist-packages
 cleanup:
   - /include


### PR DESCRIPTION
I know that now the application has access to the full home directory, but I think this should change in future and access to kdeglobals should remain, at least until we have a better way how to access configuration.