### PR TITLE
Fix access to remote shares with gvfs 1.48

### DIFF
--- a/org.kde.krita.json
+++ b/org.kde.krita.json
@@ -17,7 +17,8 @@
     "--env=TMPDIR=/var/tmp",
     /* Needed for colord to work */
     "--system-talk-name=org.freedesktop.ColorManager",
-    "--filesystem=xdg-run/gvfs"
+    "--filesystem=xdg-run/gvfs",
+    "--filesystem=xdg-run/gvfsd"
   ],
   "cleanup": [
     "/include",


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gvfs/-/issues/515#note_919326 and https://github.com/flathub/flathub/issues/2180 for more details.