### PR TITLE
Failed to download sources: module boost: 403 ERROR

### DIFF
--- a/org.kde.krita.json
+++ b/org.kde.krita.json
@@ -469,7 +469,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2",
+          "url": "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2",
           "sha256": "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"
         }
       ]


### PR DESCRIPTION
Fixed Failed to download sources: module boost: The requested URL returned error: 403 Forbidden
